### PR TITLE
Use python logging instead of custom class.

### DIFF
--- a/docs/foundation.rst
+++ b/docs/foundation.rst
@@ -71,12 +71,21 @@ If you need to initialize functions using `functools.partial <https://docs.pytho
 
 .. _logger:
 
-Logger
-======
+Logging
+=======
 
-Ocelot uses a very simple ``Logger`` class that writes messages in JSON. Log messages are written when a run is started or finished, when transformation functions are started or finished, and whenever the transformation function wants to log something. The log message format is documented in :ref:`logging-format`.
+Ocelot uses standard `python logging <https://docs.python.org/3/library/logging.html>`_, with a custom formatter that encodes log messages to JSON dictionaries. Therefore, log messages must be **dictionaries**:
 
-.. autoclass:: ocelot.Logger
+.. code-block:: python
+
+    import logging
+
+    def my_transformation(data):
+        logging.info({"message": "something", "count": len(data)})
+
+Log messages are written when a run is started or finished, when transformation functions are started or finished, and whenever the transformation function wants to log something. The log message format is documented in :ref:`logging-format`.
+
+.. note:: ``time`` is added automatically to each log message.
 
 .. _report:
 

--- a/ocelot/__init__.py
+++ b/ocelot/__init__.py
@@ -2,7 +2,7 @@
 __all__ = (
     "Configuration",
     "HTMLReport",
-    "Logger",
+    "OutputDir",
     "system_model",
 )
 
@@ -27,6 +27,6 @@ from .data import data_dir
 from .collection import Collection
 from .io import *
 from .configuration import Configuration, default_configuration
-from .logger import Logger
+from .filesystem import OutputDir
 from .report import HTMLReport
 from .model import system_model

--- a/ocelot/filesystem.py
+++ b/ocelot/filesystem.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+import appdirs
 import hashlib
 import os
 import re
 import unicodedata
-import appdirs
+import uuid
 
 re_slugify = re.compile('[^\w\s-]', re.UNICODE)
 
@@ -49,3 +50,21 @@ def get_base_output_directory():
         return create_dir(os.environ['OCELOT_OUTPUT'])
     except KeyError:
         return create_dir(appdirs.user_data_dir("Ocelot", "ocelot_runs"))
+
+
+class OutputDir(object):
+    """OutputDir is responsible for creating and managing a model run output directory."""
+    def __init__(self, dir_path=None):
+        """Create the job id and output directory"""
+        self.report_id = uuid.uuid4().hex
+        if dir_path is None:
+            dir_path = get_base_output_directory()
+        self.directory = os.path.join(dir_path, self.report_id)
+        try:
+            create_dir(self.directory)
+            assert check_dir(self.directory)
+        except:
+            raise OutputDirectoryError(
+                "Can't find or write to output directory:\n\t{}".format(
+                self.directory)
+            )

--- a/ocelot/logger.py
+++ b/ocelot/logger.py
@@ -1,74 +1,25 @@
 # -*- coding: utf-8 -*-
-from .filesystem import get_base_output_directory, create_dir, check_dir
-from time import time
 import json
+import logging
 import os
-import uuid
+import time
 
 
-class Logger(object):
-    """The ``Logger`` class provides a JSON logger for use during a model run, and formats a nice report afterwards.
+class JsonFormatter(logging.Formatter):
+    """Uses code from https://github.com/madzak/python-json-logger/ under BSD license"""
+    def format(self, record):
+        assert isinstance(record.msg, dict)
+        message_dict = record.msg
+        message_dict['time'] = time.time()
+        return json.dumps(message_dict, ensure_ascii=False)
 
-    ``Logger`` provides methods for several types of log messages.
 
-    """
-    def __init__(self, data):
-        """Initialize the log with the raw extracted data"""
-        report_id = uuid.uuid4().hex
-        self.directory = self.create_output_directory(report_id)
-        self.filepath = os.path.join(self.directory, "report.log.json")
-        print("Opening log file at: {}".format(self.filepath))
-        self.logfile = open(self.filepath, "w", encoding='utf-8')
-        self.log({
-            'count': len(data),
-            'time': time(),
-            'type': 'report start',
-            'uuid': report_id,
-        })
-        self.index = 1
-
-    def create_output_directory(self, report_id):
-        directory = os.path.join(get_base_output_directory(), report_id)
-        try:
-            create_dir(directory)
-            assert check_dir(directory)
-        except:
-            raise OutputDirectoryError(
-                "Can't find or write to output directory:\n\t{}".format(
-                directory)
-            )
-        return directory
-
-    def set_index(self, index):
-        self.index = index + 1
-
-    def log(self, message):
-        self.logfile.write(json.dumps(message) + "\n")
-
-    def start_function(self, metadata, data):
-        log_data = {
-            'type': 'function start',
-            'count': len(data),
-            'time': time(),
-            'index': self.index,
-        }
-        log_data.update(metadata)
-        self.log(log_data)
-
-    def end_function(self, metadata, data):
-        log_data = {
-            'type': 'function end',
-            'count': len(data),
-            'time': time(),
-            'index': self.index,
-        }
-        log_data.update(metadata)
-        self.log(log_data)
-
-    def finish(self, show=False):
-        self.log({
-            'type': 'report end',
-            'time': time()
-        })
-        self.logfile.close()
-        print("Generated report at: {}".format(self.filepath))
+def create_log(output_dir):
+    logger = logging.getLogger()
+    formatter = JsonFormatter()
+    filepath = os.path.join(output_dir, "report.log.json")
+    handler = logging.FileHandler(filepath, encoding='utf-8')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return filepath

--- a/ocelot/report.py
+++ b/ocelot/report.py
@@ -32,7 +32,7 @@ def jsonize(data):
 
 
 class HTMLReport(object):
-    """Generate an HTML report from a :ref:`logger` logfile.
+    """Generate an HTML report from a logfile.
 
     Reports are generated in the same directory as the logfile.
 

--- a/ocelot/transformations/__init__.py
+++ b/ocelot/transformations/__init__.py
@@ -6,7 +6,7 @@ from .parameterization import (
 )
 
 
-def dummy_transformation(data, logger):
+def dummy_transformation(data):
     """This is a dummy transformation that doesn't do anything.
 
     Used primarily for testing."""

--- a/ocelot/transformations/locations.py
+++ b/ocelot/transformations/locations.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from .. import toolz
 from ..utils import activity_grouper
+import logging
 
 
-def relabel_global_to_row(data, logger):
+def relabel_global_to_row(data):
     """Change ``GLO`` locations to ``RoW`` if there are region-specific datasets in the activity group."""
     processed = []
     for key, datasets in toolz.groupby(activity_grouper, data).items():
@@ -11,7 +12,7 @@ def relabel_global_to_row(data, logger):
             for ds in datasets:
                 if ds['location'] == 'GLO':
                     ds['location'] = 'RoW'
-                    logger.log({
+                    logging.info({
                         'type': 'table element',
                         'data': (key[0], "; ".join(sorted(key[1])))
                     })

--- a/ocelot/transformations/parameterization.py
+++ b/ocelot/transformations/parameterization.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from ..collection import Collection
 from ..errors import ParameterizationError
+import logging
 
 
-def every_exchange_with_formula_has_a_variable_name(data, logger):
+def every_exchange_with_formula_has_a_variable_name(data):
     """Data validity check."""
     for ds in data:
         for exc in ds['exchanges']:
@@ -12,7 +13,7 @@ def every_exchange_with_formula_has_a_variable_name(data, logger):
     return data
 
 
-def parameter_names_are_unique(data, logger):
+def parameter_names_are_unique(data):
     """Data validity check."""
     for ds in data:
         if not ds.get('parameters'):

--- a/tests/collection.py
+++ b/tests/collection.py
@@ -13,7 +13,7 @@ def test_empty_collection(fake_report):
 
 def test_can_pass_collection_directly(fake_report):
     """i.e. not in a list"""
-    collection = Collection(lambda x, y: x)
+    collection = Collection(lambda x: x)
     report, data = system_model([1,2,3,4], collection)
     assert data == [1,2,3,4]
 
@@ -28,16 +28,16 @@ def test_empty_collection_is_falsey():
 
 def test_collection_applied_in_order(fake_report):
     collection = Collection(
-        lambda x, y: x + [1],
-        lambda x, y: x + [2]
+        lambda x: x + [1],
+        lambda x: x + [2]
     )
     report, data = system_model([], collection)
     assert data == [1,2]
 
 def test_list_of_functions_also_possible(fake_report):
     list_of_functions = [
-        lambda x, y: x + [1],
-        lambda x, y: x + [2]
+        lambda x: x + [1],
+        lambda x: x + [2]
     ]
     report, data = system_model([], list_of_functions)
     assert data == [1,2]

--- a/tests/parameterization.py
+++ b/tests/parameterization.py
@@ -14,7 +14,7 @@ def test_parameter_names_are_unique():
             'variable': 'baz'
         }
     ]}]
-    assert parameter_names_are_unique(data, None)
+    assert parameter_names_are_unique(data)
 
 
 def test_parameter_names_are_unique_error():
@@ -26,4 +26,4 @@ def test_parameter_names_are_unique_error():
         }
     ]}]
     with pytest.raises(ParameterizationError):
-        parameter_names_are_unique(data, None)
+        parameter_names_are_unique(data)


### PR DESCRIPTION
Fixes #39.

Several clear advantages:

- Don't have to pass custom logger class to transformation functions
- Separation of previous `Logger` class into `OutputDir` (which creates the output directory), and `create_log`, which creates the log.
- Standard logging allows for plugging into library functions and package ecosystem, e.g. shipping logs.

Plus there is generally less magic.

Docs are updated, tests pass on my machine and CI.