### PR TITLE
Remove zero pv

### DIFF
--- a/ocelot/data_helpers.py
+++ b/ocelot/data_helpers.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+
+def production_volume(dataset):
+    """Get production volume of reference product exchange.
+
+    Returns ``None`` if no or multiple reference products, or if reference product doesn't have a production volume amount."""
+    exchanges = [x for x in dataset['exchanges']
+                 if x['type'] == 'reference product']
+    if len(exchanges) != 1:
+        return None
+    else:
+        try:
+            return exchanges[0]['production volume']['amount']
+        except KeyError:
+            return None
+
+
+def reference_products_as_string(dataset):
+    """Get all reference products as a string separated by ``'|'``.
+
+    Return ``'None found'`` if no reference products were found."""
+    exchanges = sorted([exc['name']
+                        for exc in dataset['exchanges']
+                        if exc['type'] == 'reference product'])
+    if not exchanges:
+        return "None found"
+    else:
+        return "|".join(exchanges)

--- a/ocelot/transformations/__init__.py
+++ b/ocelot/transformations/__init__.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 from .locations import relabel_global_to_row
+from .cleanup import (
+    drop_zero_pv_row_datasets,
+    ensure_all_datasets_have_production_volume,
+)
 from .parameterization import (
     parameterization_validity_checks,
     parameter_names_are_unique,

--- a/ocelot/transformations/cleanup.py
+++ b/ocelot/transformations/cleanup.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from ..data_helpers import (
+    production_volume,
+    reference_products_as_string,
+)
+import logging
+import pprint
+
+
+def ensure_all_datasets_have_production_volume(data):
+    """Make sure all datasets have a single reference product exchange with a valid production volume amount"""
+    for ds in data:
+        assert production_volume(ds), "Dataset does not have valid production volume:\n{}".format(pprint.pformat(ds))
+    return data
+
+
+def drop_zero_pv_row_datasets(data):
+    """Drop datasets which have the location ``RoW`` and zero production volumes.
+
+    Zero production volumes occur when all inputs have been allocated to region-specific datasets."""
+    for ds in (x for x in data if x['location'] == 'RoW'):
+        if production_volume(ds) == 0:
+            logging.info({
+                'type': 'table element',
+                'data': (ds['name'], reference_products_as_string(ds))
+            })
+    return [ds for ds in data
+            if (ds['location'] != 'RoW' or production_volume(ds) != 0)]
+
+
+drop_zero_pv_row_datasets.__table__ = {
+    'title': 'Drop `RoW` datasets with zero production volumes',
+    'columns': ["Name", "Product(s)"]
+}

--- a/tests/cleanup.py
+++ b/tests/cleanup.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from ocelot.transformations import (
+    drop_zero_pv_row_datasets,
+    ensure_all_datasets_have_production_volume,
+)
+import pytest
+
+
+### Test drop_zero_pv_row_datasets function
+
+def test_drop_zero_pv_row_datasets():
+    data = [
+        {
+            'location': 'RoW',
+            'exchanges': [{
+                'type': 'reference product',
+                'production volume': {'amount': 10}
+            }]
+        },
+        {
+            'location': 'Nowhere',
+            'exchanges': [{
+                'type': 'reference product',
+                'production volume': {'amount': 0}
+            }]
+        },
+        {
+            'name': 'foo',
+            'location': 'RoW',
+            'exchanges': [{
+                'type': 'reference product',
+                'production volume': {'amount': 0},
+                'name': 'bar'
+            }]
+        },
+    ]
+    expected = [
+        {
+            'location': 'RoW',
+            'exchanges': [{
+                'type': 'reference product',
+                'production volume': {'amount': 10}
+            }]
+        },
+        {
+            'location': 'Nowhere',
+            'exchanges': [{
+                'type': 'reference product',
+                'production volume': {'amount': 0}
+            }]
+        },
+    ]
+    # TODO: Test for logging?
+    assert drop_zero_pv_row_datasets(data) == expected
+
+
+### Test ensure_all_datasets_have_production_volume function
+
+def test_ensure_all_datasets_have_production_volume_pass():
+    data = [
+        {
+            'location': 'RoW',
+            'exchanges': [{
+                'type': 'reference product',
+                'production volume': {'amount': 10}
+            }]
+        },
+    ]
+    assert ensure_all_datasets_have_production_volume(data)
+
+def test_ensure_all_datasets_have_production_volume_fail():
+    data = [
+        {
+            'exchanges': [{
+                'type': 'something else',
+                'production volume': {'amount': 10}
+            }]
+        },
+    ]
+    with pytest.raises(AssertionError):
+        ensure_all_datasets_have_production_volume(data)

--- a/tests/data_helpers.py
+++ b/tests/data_helpers.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from ocelot.data_helpers import (
+    production_volume,
+    reference_products_as_string,
+)
+
+### Test production_volume function
+
+def test_production_volume_multiple():
+    dataset = {'exchanges': [
+        {
+            'type': 'reference product',
+        }, {
+            'type': 'reference product',
+        }
+    ]}
+    assert production_volume(dataset) is None
+
+def test_production_volume_none():
+    dataset = {'exchanges': []}
+    assert production_volume(dataset) is None
+
+def test_production_volume_no_amount():
+    dataset = {'exchanges': [
+        {
+            'type': 'reference product',
+            'production volume': {}
+        }
+    ]}
+    assert production_volume(dataset) is None
+
+def test_production_volume_keyerror():
+    dataset = {'exchanges': [
+        {
+            'type': 'reference product',
+        }
+    ]}
+    assert production_volume(dataset) is None
+
+def test_production_volume():
+    dataset = {'exchanges': [
+        {
+            'type': 'something else',
+            'production volume': {
+                'amount': 2
+            },
+        }, {
+            'type': 'reference product',
+            'production volume': {
+                'amount': 42
+            },
+        }
+    ]}
+    assert production_volume(dataset) == 42
+
+
+### Test reference_products_as_string function
+
+def test_reference_products_none():
+    dataset = {'exchanges': []}
+    assert reference_products_as_string(dataset) == "None found"
+
+def test_reference_products_single():
+    dataset = {'exchanges': [{
+        'type': 'reference product',
+        'name': 'foo'
+    }]}
+    assert reference_products_as_string(dataset) == "foo"
+
+def test_reference_products_multiple():
+    dataset = {'exchanges': [
+        {
+            'type': 'reference product',
+            'name': 'foo'
+        }, {
+            'type': 'reference product',
+            'name': 'bar'
+        }
+    ]}
+    assert reference_products_as_string(dataset) == "bar|foo"


### PR DESCRIPTION
Fix #12. Remove RoW datasets with zero production volumes. Also adds cleanup function to make sure all datasets have valid production volumes. 