### PR TITLE
Changes to prevent overrepresentation of RoW in markets

### DIFF
--- a/ocelot/transformations/locations/rest_of_world.py
+++ b/ocelot/transformations/locations/rest_of_world.py
@@ -7,7 +7,7 @@ import logging
 
 
 def relabel_global_to_row(data):
-     """Change ``GLO`` locations to ``RoW`` if there are region-specific datasets in the activity group."""
+    """Change ``GLO`` locations to ``RoW`` if there are region-specific datasets in the activity group."""
     processed = []
     for key, datasets in toolz.groupby(activity_grouper, data).items(): 
         
@@ -39,6 +39,8 @@ def relabel_global_to_row(data):
             if ds_GLO is not None:
                 rp_GLO = get_single_reference_product(ds_GLO)
                 rp_GLO['production volume']['amount'] -= non_GLO_pv
+                if rp_GLO['production volume']['amount'] < 0:
+                    rp_GLO['production volume']['amount'] = 0
                 processed.append(ds_GLO)
 
         else:

--- a/ocelot/transformations/locations/rest_of_world.py
+++ b/ocelot/transformations/locations/rest_of_world.py
@@ -9,40 +9,30 @@ import logging
 def relabel_global_to_row(data):
     """Change ``GLO`` locations to ``RoW`` if there are region-specific datasets in the activity group."""
     processed = []
-    for key, datasets in toolz.groupby(activity_grouper, data).items(): 
-        
+    for key, datasets in toolz.groupby(activity_grouper, data).items():
         if len(datasets) > 1:
-            # start non-GLO production volume at zero and set ds_GLO (the potential global dataset) to None. 
-            # This is so if there's no GLO it doesnt add a second version of the one from the previous loop
-            non_GLO_pv = 0
-            ds_GLO = None
-            
             check_single_global_dataset(datasets)
-            
+
             for ds in datasets:
-                # Identify and store the GLO dataset, change it to RoW, but don't add to processed yet
                 if ds['location'] == 'GLO':
-                    ds_GLO = ds
+                    # Need to adjust production volume by subtracting the region-specific
+                    # production volumes. We assume that each dataset has a single reference
+                    # product with a production volume.
+                    region_specific_pv = sum(
+                        get_single_reference_product(obj)['production volume']['amount']
+                        for obj in datasets
+                        if obj != ds
+                    )
+                    rp = get_single_reference_product(ds)
+                    rp['production volume']['amount'] = max(rp['production volume']['amount'] - region_specific_pv,0)
+
                     ds['location'] = 'RoW'
                     logging.info({
                         'type': 'table element',
+                        # key is activity name and list of reference products
                         'data': (key[0], "; ".join(sorted(key[1])))
                     })
-                # get the production volume from the non-GLO transformations and add it to the running total, then add it to processed
-                else:
-                    rp = get_single_reference_product(ds)
-                    non_GLO_pv += rp['production volume']['amount']
-
-                    processed.append(ds)
-
-            # subtract the non-GLO production volume from the GLO/RoW process and then append it too
-            if ds_GLO is not None:
-                rp_GLO = get_single_reference_product(ds_GLO)
-                rp_GLO['production volume']['amount'] -= non_GLO_pv
-                if rp_GLO['production volume']['amount'] < 0:
-                    rp_GLO['production volume']['amount'] = 0
-                processed.append(ds_GLO)
-
+                processed.append(ds)
         else:
             processed.extend(datasets)
     return processed

--- a/ocelot/transformations/locations/rest_of_world.py
+++ b/ocelot/transformations/locations/rest_of_world.py
@@ -7,19 +7,40 @@ import logging
 
 
 def relabel_global_to_row(data):
-    """Change ``GLO`` locations to ``RoW`` if there are region-specific datasets in the activity group."""
+     """Change ``GLO`` locations to ``RoW`` if there are region-specific datasets in the activity group."""
     processed = []
-    for key, datasets in toolz.groupby(activity_grouper, data).items():
+    for key, datasets in toolz.groupby(activity_grouper, data).items(): 
+        
         if len(datasets) > 1:
+            # start non-GLO production volume at zero and set ds_GLO (the potential global dataset) to None. 
+            # This is so if there's no GLO it doesnt add a second version of the one from the previous loop
+            non_GLO_pv = 0
+            ds_GLO = None
+            
             check_single_global_dataset(datasets)
+            
             for ds in datasets:
+                # Identify and store the GLO dataset, change it to RoW, but don't add to processed yet
                 if ds['location'] == 'GLO':
+                    ds_GLO = ds
                     ds['location'] = 'RoW'
                     logging.info({
                         'type': 'table element',
                         'data': (key[0], "; ".join(sorted(key[1])))
                     })
-                processed.append(ds)
+                # get the production volume from the non-GLO transformations and add it to the running total, then add it to processed
+                else:
+                    rp = get_single_reference_product(ds)
+                    non_GLO_pv += rp['production volume']['amount']
+
+                    processed.append(ds)
+
+            # subtract the non-GLO production volume from the GLO/RoW process and then append it too
+            if ds_GLO is not None:
+                rp_GLO = get_single_reference_product(ds_GLO)
+                rp_GLO['production volume']['amount'] -= non_GLO_pv
+                processed.append(ds_GLO)
+
         else:
             processed.extend(datasets)
     return processed

--- a/tests/locations/rest_of_world.py
+++ b/tests/locations/rest_of_world.py
@@ -14,28 +14,32 @@ def test_relabel_global_to_row():
         'location': 'GLO',
         'exchanges': [{
             'name': 'a product',
-            'type': 'reference product'
+            'type': 'reference product',
+            'production volume': {'amount': 0}
         }]
     }, {
         'name': 'make something',
         'location': 'somewhere else',
         'exchanges': [{
             'name': 'a product',
-            'type': 'reference product'
+            'type': 'reference product',
+            'production volume': {'amount': 0}
         }]
     }, {
         'name': 'make something else',
         'location': 'GLO',
         'exchanges': [{
             'name': 'a product',
-            'type': 'reference product'
+            'type': 'reference product',
+            'production volume': {'amount': 0}
         }]
     }, {
         'name': 'make something else',
         'location': 'somewhere else',
         'exchanges': [{
             'name': 'a product',
-            'type': 'reference product'
+            'type': 'reference product',
+            'production volume': {'amount': 0}
         }]
     }]
     expected = [{
@@ -43,28 +47,32 @@ def test_relabel_global_to_row():
         'location': 'RoW',
         'exchanges': [{
             'name': 'a product',
-            'type': 'reference product'
+            'type': 'reference product',
+            'production volume': {'amount': 0}
         }]
     }, {
         'name': 'make something',
         'location': 'somewhere else',
         'exchanges': [{
             'name': 'a product',
-            'type': 'reference product'
+            'type': 'reference product',
+            'production volume': {'amount': 0}
         }]
     }, {
         'name': 'make something else',
         'location': 'RoW',
         'exchanges': [{
             'name': 'another product',
-            'type': 'reference product'
+            'type': 'reference product',
+            'production volume': {'amount': 0}
         }]
     }, {
         'name': 'make something else',
         'location': 'somewhere else',
         'exchanges': [{
             'name': 'another product',
-            'type': 'reference product'
+            'type': 'reference product',
+            'production volume': {'amount': 0}
         }]
     }]
     # Can't directly compare dictionaries if order has changed
@@ -178,3 +186,91 @@ def test_drop_zero_pv_row_datasets():
         },
     ]
     assert drop_zero_pv_row_datasets(data) == expected
+
+
+def test_relabel_global_to_row_subtract_pv():
+    given = [{
+        'name': 'make something',
+        'location': 'GLO',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':100
+            }
+        }]
+    }, {
+        'name': 'make something',
+        'location': 'somewhere else',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':10
+            }
+        }]
+    }, {
+        'name': 'make something else',
+        'location': 'GLO',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':100
+            }
+        }]
+    }, {
+        'name': 'make something else',
+        'location': 'somewhere else',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':50
+            }
+        }]
+    }]
+    expected = [{
+        'name': 'make something',
+        'location': 'RoW',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':90
+            }
+        }]
+    }, {
+        'name': 'make something',
+        'location': 'somewhere else',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':10
+            }
+        }]
+    }, {
+        'name': 'make something else',
+        'location': 'RoW',
+        'exchanges': [{
+            'name': 'another product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':50
+            }
+        }]
+    }, {
+        'name': 'make something else',
+        'location': 'somewhere else',
+        'exchanges': [{
+            'name': 'another product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':50
+            }
+        }]
+    }]
+    # Can't directly compare dictionaries if order has changed
+    hashify = lambda x: {(y['name'], y['location'], y['exchanges'][0]['production volume']['amount']) for y in x}
+    assert hashify(relabel_global_to_row(given)) == hashify(expected)

--- a/tests/locations/rest_of_world.py
+++ b/tests/locations/rest_of_world.py
@@ -274,3 +274,90 @@ def test_relabel_global_to_row_subtract_pv():
     # Can't directly compare dictionaries if order has changed
     hashify = lambda x: {(y['name'], y['location'], y['exchanges'][0]['production volume']['amount']) for y in x}
     assert hashify(relabel_global_to_row(given)) == hashify(expected)
+
+def test_relabel_global_to_row_subtract_pv_overspecified_regional_pv():
+    given = [{
+        'name': 'make something',
+        'location': 'GLO',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':100
+            }
+        }]
+    }, {
+        'name': 'make something',
+        'location': 'somewhere else',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':110
+            }
+        }]
+    }, {
+        'name': 'make something else',
+        'location': 'GLO',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':100
+            }
+        }]
+    }, {
+        'name': 'make something else',
+        'location': 'somewhere else',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':150
+            }
+        }]
+    }]
+    expected = [{
+        'name': 'make something',
+        'location': 'RoW',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':0
+            }
+        }]
+    }, {
+        'name': 'make something',
+        'location': 'somewhere else',
+        'exchanges': [{
+            'name': 'a product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':110
+            }
+        }]
+    }, {
+        'name': 'make something else',
+        'location': 'RoW',
+        'exchanges': [{
+            'name': 'another product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':0
+            }
+        }]
+    }, {
+        'name': 'make something else',
+        'location': 'somewhere else',
+        'exchanges': [{
+            'name': 'another product',
+            'type': 'reference product',
+            'production volume':{
+                'amount':150
+            }
+        }]
+    }]
+    # Can't directly compare dictionaries if order has changed
+    hashify = lambda x: {(y['name'], y['location'], y['exchanges'][0]['production volume']['amount']) for y in x}
+    assert hashify(relabel_global_to_row(given)) == hashify(expected)


### PR DESCRIPTION
In the course of writing up the project report from the summer school, i noticed that RoW processes were being over represented in market processes because they retained the global production volume after they'd been renamed from GLO to RoW.

I've added this fix (with its test) to my fork of Ocelot, which may (or may not) be worth pulling into the master.

As `relabel_global_to_row` renames transforming activities from GLO to RoW it now sums up the production volumes for the specific regions and subtracts them from the GLO/RoW production volume before adding it to the processed dataset