### PR TITLE
Ecoinvent 3.3 compatability - IAI locations

### DIFF
--- a/ocelot/transformations/locations/_topology.py
+++ b/ocelot/transformations/locations/_topology.py
@@ -15,6 +15,13 @@ class Topology(object):
         ('IAI Area 3', "IAI Area 3, South America"),
         ("IAI Area 4&5 without China", 'IAI Area 4&5, without China'),
         ('IAI Area 8', "IAI Area 8, Gulf"),
+        # Compatability for ecoinvent 3.3
+        ('IAI Area, North America, without Quebec', 'IAI Area 2, without Quebec'),
+        ('IAI Area, South America', 'IAI Area 3, South America'),
+        ('IAI Area, Russia & RER w/o EU27 & EFTA', 'IAI Area, Europe outside EU & EFTA'),
+        ('IAI Area, Asia, without China and GCC', 'IAI Area 4&5, without China'),
+        ('IAI Area, Gulf Cooperation Council', 'IAI Area 8, Gulf'),
+        ('IAI Area, Africa', 'IAI Area 1, Africa'),
     ]
 
     def __init__(self):

--- a/tests/locations/topology.py
+++ b/tests/locations/topology.py
@@ -23,6 +23,10 @@ def test_topology_intersects():
     assert topology.intersects('RoW') == set()
     # Test compatibility labels
     assert topology.intersects('IAI Area 8')
+    # Test new Ecoinvent 3.3 compatablility labels
+    assert topology.intersects('IAI Area, Asia, without China and GCC')
+    assert topology.intersects('IAI Area, Gulf Cooperation Council')
+
     with pytest.raises(KeyError):
         topology.intersects('foo')
 


### PR DESCRIPTION
Trying to process ecoinvent 3.3 spold files fails due to changes in the nomenclature for IAI areas in the new dataset. I've added the following to the compatability list in `_topology.py`

![image](https://cloud.githubusercontent.com/assets/11718809/18786456/457195ec-819e-11e6-80c9-631d3374d9c2.png)

The updated test is also included in the latest commit