### PR TITLE
Obsolete activity links

### DIFF
--- a/docs/data_format.rst
+++ b/docs/data_format.rst
@@ -27,6 +27,7 @@ Here is the validation schema for an activity dataset:
         'end date': str, # Starting and ending dates for dataset validity, in format '2015-12-31'
         'filepath': str,
         'id': str,  # Imported UUID. May not be unique due to allocation.
+        'parent': str or None, # UUID of parent activity, if present.
         # Guaranteed unique hash code based on dataset attributes like name, location, type, etc.
         Optional("code"): str,
         'location': str, # ecospold2 field 410: shortname

--- a/ocelot/configuration.py
+++ b/ocelot/configuration.py
@@ -8,6 +8,7 @@ from .transformations import (
     manage_activity_links,
     normalize_reference_production_amount,
     pv_cleanup,
+    update_activity_link_parent_child,
     validate_markets,
     variable_names_are_unique,
 )
@@ -48,6 +49,7 @@ cutoff_config = Collection(
     pv_cleanup,
     remove_consequential_exchanges,
     cleanup_activity_links,
+    update_activity_link_parent_child,
     manage_activity_links,
     handle_waste_outputs,
     cutoff_allocation,

--- a/ocelot/filesystem.py
+++ b/ocelot/filesystem.py
@@ -9,7 +9,7 @@ import unicodedata
 import uuid
 
 # Ecospold 2 extractor version. Bump this to invalidate all caches.
-__io_version__ = "7"
+__io_version__ = "8"
 
 re_slugify = re.compile('[^\w\s-]', re.UNICODE)
 

--- a/ocelot/io/extract_ecospold2.py
+++ b/ocelot/io/extract_ecospold2.py
@@ -176,6 +176,7 @@ def extract_ecospold2_dataset(elem, filepath):
     data = {
         'filepath': filepath,
         'id': elem.activityDescription.activity.get('id'),
+        'parent': elem.activityDescription.activity.get('parentActivityId'),
         'name': elem.activityDescription.activity.activityName.text,
         'location': elem.activityDescription.geography.shortname.text,
         'type': SPECIAL_ACTIVITY_TYPE[elem.activityDescription.activity.get('specialActivityType')],

--- a/ocelot/io/validate_internal.py
+++ b/ocelot/io/validate_internal.py
@@ -174,6 +174,7 @@ dataset_schema = Schema({
     'end date': str, # Starting and ending dates for dataset validity, in format '2015-12-31'
     'filepath': str,
     'id': str,  # Imported UUID. May not be unique due to allocation.
+    'parent': Any(None, str),
     # Guaranteed unique hash code based on dataset attributes like name, location, type, etc.
     Optional("code"): str,
     'location': str, # ecospold2 field 410: shortname

--- a/ocelot/transformations/__init__.py
+++ b/ocelot/transformations/__init__.py
@@ -4,6 +4,7 @@ from .activity_links import (
     check_activity_link_validity,
     add_hard_linked_production_volumes,
     manage_activity_links,
+    update_activity_link_parent_child,
 )
 from .cleanup import ensure_all_datasets_have_production_volume
 from .parameterization import (

--- a/tests/data/basic.xml
+++ b/tests/data/basic.xml
@@ -2,7 +2,7 @@
 <ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
   <childActivityDataset>
     <activityDescription>
-      <activity id="basic-process" specialActivityType="0">
+      <activity id="basic-process" specialActivityType="0" parentActivityId="some uuid">
         <activityName>Miss Morgan Wolf</activityName>
       </activity>
       <classification>

--- a/tests/data/parameterized_multioutput.xml
+++ b/tests/data/parameterized_multioutput.xml
@@ -2,7 +2,7 @@
 <ecoSpold xmlns="http://www.EcoInvent.org/EcoSpold02">
   <activityDataset>
     <activityDescription>
-      <activity id="multioutput-process" specialActivityType="0">
+      <activity id="multioutput-process" specialActivityType="0" parentActivityId="some uuid">
         <activityName>Aliana Price</activityName>
       </activity>
       <classification>

--- a/tests/io/extractions.py
+++ b/tests/io/extractions.py
@@ -14,6 +14,7 @@ BASIC_REFERENCE = [{
     'economic scenario': 'Business-as-Usual',
     'parameters': [],
     'id': 'basic-process',
+    'parent': 'some uuid',
     'exchanges': [{
         'amount': -0.99,
         'conditional exchange': False,
@@ -138,6 +139,7 @@ PROD_VOLUME_REFERENCE = [{
     'technology level': 'modern',
     'parameters': [],
     'id': 'production-volume',
+    'parent': None,
     'access restricted': 'licensees',
     'dataset author': "Fred",
     'data entry': "Wilma",
@@ -218,6 +220,7 @@ MULTIOUTPUT_REFERENCE = [{
     ],
     'location': 'GLO',
     'id': 'multioutput-process',
+    'parent': 'some uuid',
     'name': 'Aliana Price',
     'parameters': [{
         'amount': 42.0,

--- a/tests/parameterization/production_volumes.py
+++ b/tests/parameterization/production_volumes.py
@@ -10,6 +10,7 @@ def test_create_pv_parameters_format():
         'end date': '',
         'filepath': '',
         'id': '',
+        'parent': '',
         'location': '',
         'start date': '',
         'type': 'transforming activity',

--- a/tests/transformations/activity_links.py
+++ b/tests/transformations/activity_links.py
@@ -3,9 +3,15 @@ from ocelot.errors import UnresolvableActivityLink
 from ocelot.transformations.activity_links import (
     add_hard_linked_production_volumes,
     check_activity_link_validity,
+    update_activity_link_parent_child,
 )
 import pytest
 
+
+def test_update_activity_link_parent_child():
+    given = []
+    expected = []
+    assert update_activity_link_parent_child(given) == expected
 
 def test_check_activity_link_validity_ref_product():
     ref_prod = [{


### PR DESCRIPTION
Remove activity links from parent datasets which mistakenly got transferred to child datasets